### PR TITLE
Add a CI workflow using neo4j.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,47 @@
+#
+# Copyright 2022 The AFF Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Neo4j CI
+
+on:
+  workflow_dispatch:  # testing only, trigger manually to test it works
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  build:
+    name: CI using Neo4j
+    runs-on: ubuntu-latest
+    services:
+      neo4j:
+        image: neo4j:latest # TODO(mihaimaruseac): Pin to hash
+        env:
+          NEO4J_AUTH: none
+        ports:
+          - 7687:7687
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+    - name: setup-go
+      uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # tag=v3.2.1
+      with:
+        go-version: '1.18'
+    - name: Run tests # Faked now by running a go program
+      working-directory: .github/workflows/go_demo
+      run: go run main.go

--- a/.github/workflows/go_demo/go.mod
+++ b/.github/workflows/go_demo/go.mod
@@ -1,0 +1,7 @@
+module test
+
+go 1.18
+
+require (
+  github.com/neo4j/neo4j-go-driver/v4 v4.3.8
+)

--- a/.github/workflows/go_demo/go.sum
+++ b/.github/workflows/go_demo/go.sum
@@ -1,0 +1,2 @@
+github.com/neo4j/neo4j-go-driver/v4 v4.3.8 h1:dxAANPUfpUIWA5QnMFgAj2Pppjrb+84sAvoMdJ7E3aA=
+github.com/neo4j/neo4j-go-driver/v4 v4.3.8/go.mod h1:HQcN7yHl5H0hJKaYuF3TBH9m/Ym0C0ua4NHzKUr9uSc=

--- a/.github/workflows/go_demo/main.go
+++ b/.github/workflows/go_demo/main.go
@@ -1,0 +1,135 @@
+//
+// Copyright 2022 The AFF Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
+)
+
+const (
+	dbUri    string = "neo4j://localhost:7687"
+	username        = "neo4j"
+	password        = "neo4j"
+)
+
+func main() {
+	driver, err := neo4j.NewDriver(dbUri, neo4j.BasicAuth(username, password, ""))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Connected to %v\n", dbUri)
+	defer driver.Close()
+
+	createGraph(driver)
+	retrieveGraph(driver)
+}
+
+func createGraph(driver neo4j.Driver) {
+	session := driver.NewSession(neo4j.SessionConfig{})
+	defer session.Close()
+
+	nodes := []string{"Hello world!", "Welcome to AFF."}
+	for _, msg := range nodes {
+		_, err := session.WriteTransaction(createNode(msg))
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	_, err := session.WriteTransaction(createEdge(nodes[0], nodes[1]))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func retrieveGraph(driver neo4j.Driver) {
+	session := driver.NewSession(neo4j.SessionConfig{})
+	defer session.Close()
+
+	readers := []func(neo4j.Transaction)(interface{}, error){matchNodes, matchEdges}
+	for _, reader := range readers {
+		_, err := session.ReadTransaction(reader)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// Neo4J Query functions
+
+func createNode(msg string) func(neo4j.Transaction) (interface{}, error) {
+	return func(tx neo4j.Transaction) (interface{}, error) {
+		_, err := tx.Run("CREATE (a:Msg { text: $text })", map[string]interface{}{
+			"text": msg,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+}
+
+func createEdge(msg1 string, msg2 string) func(neo4j.Transaction) (interface{}, error) {
+	return func(tx neo4j.Transaction) (interface{}, error) {
+		_, err := tx.Run("MATCH (a:Msg), (b:Msg) WHERE a.text = $msg1 AND b.text = $msg2 CREATE (a)-[:Link]->(b)", map[string]interface{}{
+			"msg1": msg1,
+			"msg2": msg2,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+}
+
+func matchNodes(tx neo4j.Transaction) (interface{}, error) {
+	records, err := tx.Run("MATCH (a:Msg) RETURN a", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Found the following nodes: \n")
+	for records.Next() {
+		record := records.Record()
+		fmt.Printf("\t%v\n", record)
+	}
+	if err = records.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func matchEdges(tx neo4j.Transaction) (interface{}, error) {
+	records, err := tx.Run("MATCH (a:Msg)-[:Link]->(b:Msg) RETURN a, b", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Found the following links: \n")
+	for records.Next() {
+		record := records.Record()
+		fmt.Printf("\t%v\n", record)
+	}
+	if err = records.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
This has dual purpose:
- we are adding some CI to the repository, which will evolve shortly as we keep adding glue/starter code and actual tests, etc.
- we are testing using neo4j from docker and creating a reproducible build/test environment that developers can use for testing on their  machine too

The local go files are temporary, for testing purposes only. Still, please review them as I'm learning go while doing this :)

---

### To test locally 

In one terminal run the neo4j docker service

```console
$ docker run --name aff -it -d --env NEO4J_AUTH=none -p=7474:7474 -p=7687:7687 neo4j
```

Then in another terminal, you can either connect to this docker instance and run Cipher queries manually (via `docker exec --interactive --tty aff cypher-shell`) or run the test suite/code:

```console
$ go run main.go 
Connected to neo4j://localhost:7687
Found the following nodes: 
	&{[{0 [Msg] map[text:Hello world!]}] [a]}
	&{[{1 [Msg] map[text:Welcome to AFF.]}] [a]}
Found the following links: 
	&{[{0 [Msg] map[text:Hello world!]} {1 [Msg] map[text:Welcome to AFF.]}] [a b]}
```

When done, terminate the docker instance

```console
$ docker stop aff; docker rm aff
```

---

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>